### PR TITLE
RichText Polymorphic Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,64 @@ Cheers,
 
 If you're attaching models, you can implement the `richTextAsPlainText(?string $caption = null): string` method on it, where you should return the plain text representation of that attachable. If the method is not implemented on the attachable and no caption is stored in the Trix attachment, that attachment won't be present in the Plain Text version of the content.
 
+### Sanitization
+<a name="sanitization"></a>
+
+Since we're output unescaped HTML, you need to sanitize to avoid any security issues. One suggestion is to to use the [mews/purifier](https://github.com/mewebstudio/Purifier) package, before any final render (with the exception of rendering inside the value attribute of the input field that feeds Trix). That would look like this:
+
+```php
+{!! clean($post->body) !!}
+```
+
+You need to add some customizations to the config file created when you install the `mews/purifier` package, like so:
+
+```php
+return [
+    // ...
+    'settings' => [
+        // ...
+        'default' => [
+            // ...
+            'HTML.Allowed' => 'rich-text-attachment[sgid|content-type|url|href|filename|filesize|height|width|previewable|presentation|caption|data-trix-attachment|data-trix-attributes],div,b,strong,i,em,u,a[href|title|data-turbo-frame],ul,ol,li,p[style],br,span[style],img[width|height|alt|src],del,h1,blockquote,figure[data-trix-attributes|data-trix-attachment],figcaption,*[class]',
+        ],
+        // ...
+        'custom_definition' => [
+            // ...
+            'elements' => [
+                // ...
+                ['rich-text-attachment', 'Block', 'Flow', 'Common'],
+            ],
+        ],
+        // ...
+        'custom_attributes' => [
+            // ...
+            ['rich-text-attachment', 'sgid', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'content-type', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'url', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'href', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'filename', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'filesize', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'height', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'width', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'previewable', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'presentation', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'caption', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'data-trix-attachment', new HTMLPurifier_AttrDef_Text],
+            ['rich-text-attachment', 'data-trix-attributes', new HTMLPurifier_AttrDef_Text],
+            ['figure', 'data-trix-attachment', new HTMLPurifier_AttrDef_Text],
+            ['figure', 'data-trix-attributes', new HTMLPurifier_AttrDef_Text],
+        ],
+        // ...
+        'custom_elements' => [
+            // ...
+            ['rich-text-attachment', 'Block', 'Flow', 'Common'],
+        ],
+    ],
+];
+```
+
+**Attention**: I'm not an expert in HTML content sanitization, so take this with an extra grain of salt and, please, consult someone more with more security experience on this if you can.
+
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,11 +24,132 @@ You can install the package via composer:
 composer require tonysm/rich-text-laravel
 ```
 
+Then, you may install it running:
+
+```bash
+php artisan richtext:install
+```
+
+This will install the package with the recommended model structure. However, you may choose to not want any of the database opinions and only use the custom cast. To achieve that, you may pass the `--no-model` flag:
+
+```bash
+php artisan richtext:install --no-model
+```
+
+This will only make sure you have the latest version of Trix installed locally and from there, you can use the custom cast on your model. You can find more information about the recommended database structure at the [rich text model](#rich-text-model) section.
+
 ## Usage
 
-We're going to extract attachments before saving the rich text field (which uses Trix) in the database. We replace the attachment with `rich-text-attachment` tag with an `sgid`. When rendering that rich content again, we can render the attachables. This works for Remote URLs and for any Attachable record (more on that later).
+We're going to extract attachments before saving the rich text field (which uses Trix) in the database and minimize the content for storage. We replace the attachments with `rich-text-attachment` tags. If the attachment for a model attachable, we store a `sgid` which should globally identify that model. When storing images directly (say, for a simple image uploading where you don't have a model for representing that image on your application), we'll fill the `rich-text-attachment` with all the attachment's properties needded to render that image again. Storing a minimized (canonical) version of the rich text content means we don't store the inner contents of the attachment tags, only the metadata needded to render it again when needed.
 
-The way this works is that we're going to add cast to any Rich Text field on any model, like so:
+There are two ways of using the package:
+
+1. With the recommended database structure where all rich text content will be stored outside of the model that has rich text content (recommended); and
+1. Only using the `AsRichTextContent` trait to cast a rich text content field on any model, on any table you want.
+
+Below, we cover each usage way.
+
+### The RichText Model
+<a name="rich-text-model"></a>
+
+The recommended way is to keep the rich text content outside of the model itself. This will keep the models lean when you're manipulating them, and you can (eagerly or lazily) load the rich text fields only where you need the rich text content.
+
+Here's how you would have two rich text fields on a Post model, say you need one for the body of the content and another one for internal notes you may have:
+
+```php
+use Tonysm\RichTextLaravel\Models\Traits\HasRichText;
+
+class Post extends Model
+{
+    use HasRichText;
+
+    protected $guarded = [];
+
+    protected $richTextFields = [
+        'body',
+        'notes',
+    ];
+}
+```
+
+This trait will create [dynamic relationships](https://laravel.com/docs/8.x/eloquent-relationships#dynamic-relationships) on the Post model, one for each field. These relationships will be called: `richText{FieldName}` and you may define the fields using underscore, so if you had a `internal_notes` field, that would have a `richTextInternalNotes` relationship added on the model.
+
+For a better DX, the trait will also add a custom cast for the `body` and `notes` fields on the Post model to forward setting/getting operations to the relationship, since these fields will NOT be stored in the posts table. This means that you can use the Post model like this:
+
+```php
+$post = Post::create(['body' => $body, 'notes' => $notes]);
+```
+
+And you can interact with the rich text fields just like you would with any regular field on the Post model:
+
+```php
+$post->body->render();
+```
+
+Again, there's no `body` or `notes` fields on the Post model, these _virtual fields_ will forward interactions to the relationship of that field. This means that when you interact with these fields, you're actually interacting with an instance of the `RichText` model. That model will have a `body` field that holds the rich text content. This field is then casted to an instance of the [`Content`](./src/Content.php) class. Calls to the RichText model will be forwarded to the `body` field on the `RichText` model, which is an instance of the `Content` class. This means that instead of:
+
+```php
+$post->body->body->attachments();
+```
+
+Where the first "body" is the virtual field which will be an instance of the RichText model and the second "body" is the rich text content field on that model, which is an instance of the `Content` class, you can do:
+
+```php
+$post->body->attachments();
+```
+
+Similarly to the Content class, the RichText model will implement the `__toString` magic method and render the HTML content (for the end user) by casting it to a string, which in blade can be done like this:
+
+```blade
+{!! $post->body !!}
+```
+
+*Note*: since the HTML output is NOT escaped, make sure you sanitize it before rendering. You can use something like the [mews/purifier](https://github.com/mewebstudio/Purifier) package, see the [sanitization](#sanitization) section for more about this.
+
+The `HasRichText` trait will also add an scope which you can use to eager load the rich text fields (remember, each field will have its own relationship), which you can use like so:
+
+```php
+// Loads all rich text fields (1 query for each field, since each has its own relationship)
+Post::withRichText()->get();
+
+// Loads only a specific field:
+Post::withRichText('body')->get();
+
+// Loads some specific fields (but not all):
+Post::withRichText(['body', 'notes'])->get();
+```
+
+The database structure for this example would be something like this:
+
+```
+posts
+    id (primary key)
+    created_at (timestamp)
+    updated_at (timestamp)
+
+rich_texts
+    id (primary key)
+    field (string)
+    body (long text)
+    created_at (timestamp)
+    updated_at (timestamp)
+```
+
+We store a back-reference to the field name in the `rich_texts` table because a model may have multiple rich text fields, so that is used in the dynamic relationship the `HasRichText` creates for you. There's also a unique constraint on this table, which prevents having multiple entries for the same model/field pair.
+
+Rendering the rich text content back to the Trix editor is a bit differently than rendering for the end users, so you may do that using the `toTrixHtml` method on the field, like so:
+
+```blade
+<input id="post_body" value="{!! $post->body->toTrixHtml() !!}" type="hidden" />
+<trix-editor input="post_body" class="trix-content"></trix-editor>
+```
+
+Next, go to the [attachments](#attachments) section to read more about attachables.
+
+### The AsRichTextContent Trait
+<a name="asrichtextcontent-trait"></a>
+
+In case you don't want to use the recommended structure (either because you have strong opinions here or you want to rule your own database structure), you may skip the entire recommended database structure and use the `AsRichTextContent` custom cast on your rich text content field. For instance, if you're storing the `body` field on the `posts` table, you may do it like so:
 
 ```php
 use Tonysm\RichTextLaravel\Casts\AsRichTextContent;
@@ -36,44 +157,40 @@ use Tonysm\RichTextLaravel\Casts\AsRichTextContent;
 class Post extends Model
 {
     protected $casts = [
-        'content' => AsRichTextContent::class,
+        'body' => AsRichTextContent::class,
     ];
 }
 ```
 
-Then caster will parse the HTML content and minify it for storage. Essentially, it will convert this image attachment:
+Then the custom cast will parse the HTML content and minify it for storage. Essentially, it will convert this content submitted by Trix which has only an image attachment:
 
 ```php
 $post->update([
     'content' => <<<HTML
-    <div>
-        <h1>Hello World</h1>
-        <figure data-trix-attachment='{
-            "url": "http://example.com/blue.jpg",
-            "width": 300,
-            "height": 150,
-            "contentType": "image/jpeg",
-            "caption": "Something cool",
-            "filename":"blue.png",
-            "filesize":1168
-        }'>
-            <img src="http://example.com/blue.jpg" width="300" height="150" />
-            <caption>
-                Something cool
-            </caption>
-        </figure>
-    </div>
+    <h1>Hello World</h1>
+    <figure data-trix-attachment='{
+        "url": "http://example.com/blue.jpg",
+        "width": 300,
+        "height": 150,
+        "contentType": "image/jpeg",
+        "caption": "Something cool",
+        "filename":"blue.png",
+        "filesize":1168
+    }'>
+        <img src="http://example.com/blue.jpg" width="300" height="150" />
+        <caption>
+            Something cool
+        </caption>
+    </figure>
     HTML,
 ])
 ```
 
-to this minified version:
+To this minified version:
 
 ```html
-<div>
-    <h1>Hello World</h1>
-    <rich-text-attachment content-type="image/jpeg" filename="blue.png" filesize="1168" height="300" href="http://example.com/blue.jpg" url="http://example.com/blue.jpg" width="300" caption="testing this caption" presentation="gallery"></rich-text-attachment>
-</div>
+<h1>Hello World</h1>
+<rich-text-attachment content-type="image/jpeg" filename="blue.png" filesize="1168" height="300" href="http://example.com/blue.jpg" url="http://example.com/blue.jpg" width="300" caption="testing this caption" presentation="gallery"></rich-text-attachment>
 ```
 
 And when it renders it again, it will re-render the remote image again inside the `rich-text-attachment` tag. You can render the content for *viewing* by simply echoing out the output, something like this:
@@ -82,23 +199,23 @@ And when it renders it again, it will re-render the remote image again inside th
 {!! $post->content !!}
 ```
 
-*Note*: since the HTML output is NOT escaped, make sure you sanitize it before rendering. You can use something like the [mews/purifier](https://github.com/mewebstudio/Purifier) package, which would look like this:
-
-```blade
-{!! clean($post->content) !!}
-```
+*Note*: since the HTML output is NOT escaped, make sure you sanitize it before rendering. You can use something like the [mews/purifier](https://github.com/mewebstudio/Purifier) package, see the [sanitization](#sanitization) section for more about this.
 
 When feeding the Trix editor again, you need to do it differently:
 
 ```blade
-<x-trix-editor :value="$post->content->toTrixHtml()" />
+<input id="post_body" value="{!! $post->body->toTrixHtml() !!}" type="hidden" />
+<trix-editor input="post_body" class="trix-content"></trix-editor>
 ```
 
 Rendering for the editor is a bit different, so it has to be like that.
 
-### Attaching Models
+### Trix Attachments
+<a name="attachments"></a>
 
-You can have any model on your application as attachable inside a Trix rich text field. To do that, you need to implement the `AttachableContract` and use the `Attachable` trait in a model. Besides that, you also have to implement a `richTextRender(array $options): string` where you can tell the package how to render that model inside Trix:
+Trix has a concept of Attachments. A common example is attaching images. Trix already ships with an image attachment toolbar button, you only have to implement the actual uploading of the image. Uploaded images may not need a model representation on your application, so you can just have it as a remote image. See the [image upload](#image-upload) section for more about this.
+
+Although images make a straight-forward example, you can actually attach anything to your Trix rich text content. For instance, you may want to implement a mentions feature inside the editor, so you would want to make the User model a Trix attachable. To do that, you may implement the `AttachableContract` and use the `Attachable` trait in a model. Besides that, you may also implement a `richTextRender(array $options): string` where you tell the package how to render that model inside Trix:
 
 ```php
 use Tonysm\RichTextLaravel\Attachables\AttachableContract;
@@ -119,17 +236,176 @@ class User extends Model implements AttachableContract
 
 Then inside that `users._mention` Blade template you have full control over the HTML for this attachable field.
 
-TODO: document the options array.
+The `$options` array is there in case you're rendering multiple models inside a gallery, so you would get a `in_gallery` boolean field (optional) in thase case, which is not the case for this user mentions example, so we can simply ignore it.
 
-### Getting Attachables
+Trix content can also be converted to Plain Text, so you optionally implement the `richTextAsPlainText()`  method on any attachable and return a plain text string corresponding to that attachment. Read more about this in the [plain text](#plain-text) section.
 
-You can retrieve all the attachments of a rich content field using the `attachments()` method from the content instance:
+##### Getting Attachables
+
+You may retrieve all the attachments of a rich content field using the `attachments()` method both in the RichText model instance or the Content instance:
 
 ```php
-$post->content->attachments()
+$post->body->attachments()
 ```
 
-This will return a collection of all the attachments (anything that is an attachable, really, so images and users, for instance - if you want only attachments of a specific attachable you can use the filter method on the collection).
+This will return a collection of all the attachments, anything that is an attachable, really, so images and users, for instance - if you want only attachments of a specific attachable you can use the filter method on the collection, like so:
+
+```php
+// Getting only attachments of users inside the rich text content.
+
+$post->body->attachments()
+    ->filter(fn (Attachment $attachment) => $attachment->attachable instanceof User)
+    ->unique();
+```
+
+In our user mentions implementation, this may be useful so we can sync the mentions relationship in the post model with all the user attachments in the rich text content, here's a semi-complete implementation of the mentions feature, where we store the mentions associated with the Post and we sync those up everytime the Post model changes to make sure users get the notification even when the Post is updated afterwards to include their mention:
+
+```php
+class User extends Model implements AttachableContract
+{
+    use Attachable;
+
+    public function mentions()
+    {
+        return $this->hasMany(Mention::class);
+    }
+
+    public function richTextRender(array $options = []): string
+    {
+        return view('users._mention', [
+            'user' => $this,
+        ])->render();
+    }
+}
+
+class Mention extends Model
+{
+    public static function booted()
+    {
+        static::created(queueable(function (Mention $mention) {
+            $mention->sendUserNotification();
+        }));
+    }
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function sendUserNotification(): void
+    {
+        $this->user->notify(new MentionedNotification($mention));
+    }
+}
+
+class Post extends Model
+{
+    use HasRichText;
+
+    protected $guarded = [];
+
+    protected $richTextFields = [
+        'body',
+    ];
+
+    public static function booted()
+    {
+        static::saved(queueable(function (Post $post) {
+            $post->syncMentions();
+        }));
+    }
+
+    public function mentions()
+    {
+        return $this->hasMany(Mention::class);
+    }
+
+    public function syncMentions(): void
+    {
+        $attachedUsers = $this->body->attachments()
+            ->filter(fn (Attachment $attachment) => $attachment->attachable instanceof User)
+            ->map(fn (Attachment $attachment) => $attachment->attachable)
+            ->unique();
+
+        $this->loadMissing('mentions.user');
+
+        // Remove mentions for users that are no longer attached in the content...
+        $this->mentions->filter(fn (Mention $mention) => (
+            null === $attachedUsers->first(fn (User $user) => $mention->user->is($user)))
+        ))->each->delete();
+
+        // Create mentions for users that are now listed and there are no prior mentions for them...
+        $newMentions = $attachedUsers->filter(fn (User $user) => (
+            null === $this->mentions->first(fn (Mention $mention) => $mention->user->is($user))
+        ))->map(fn (User $user) => $user->mentions()->make());
+
+        if ($newMentions->isNotEmpty()) {
+            $this->mentions()->saveMany($newMentions);
+        }
+
+        $this->mentions->merge($newMentions);
+    }
+}
+```
+
+### Image Upload
+<a name="image-upload"></a>
+
+TODO
+
+### Plain Text Rendering
+<a name="plain-text"></a>
+
+Trix content can be converted to anything. This essentially means `HTML > something`. The package ships with a `HTML > Plain Text` implementation, so you can convert any Trix content to plain text by calling the `toPlainText()` method on it:
+
+```php
+$post->body->toPlainText()
+```
+
+As an example, this rich text content:
+
+```html
+<h1>Very Important Message<h1>
+<p>This is an important message, with the following items:</p>
+<ol>
+    <li>first item</li>
+    <li>second item</li>
+</ol>
+<p>And here's an image:</p>
+<rich-text-attachment content-type="image/jpeg" filename="blue.png" filesize="1168" height="300" href="http://example.com/blue.jpg" url="http://example.com/blue.jpg" width="300" caption="The caption of the image" presentation="gallery"></rich-text-attachment>
+<br><br>
+<p>With a famous quote</p>
+<blockquote>Lorem Ipsum Dolor - Lorense Ipsus</blockquote>
+<p>Cheers,</p>
+```
+
+Will be converted to:
+
+```plaintext
+Very Important Message
+
+This is an important message, with the following items:
+
+    1. first item
+    1. second item
+
+And here's an image:
+
+[The caption of the image]
+
+With a famous quote
+
+“Lorem Ipsum Dolor - Lorense Ipsus”
+
+Cheers,
+```
+
+If you're attaching models, you can implement the `richTextAsPlainText(?string $caption = null): string` method on it, where you should return the plain text representation of that attachable. If the method is not implemented on the attachable and no caption is stored in the Trix attachment, that attachment won't be present in the Plain Text version of the content.
 
 ## Testing
 

--- a/config/rich-text-laravel.php
+++ b/config/rich-text-laravel.php
@@ -1,5 +1,8 @@
 <?php
-// config for Tonysm/ClassName
-return [
 
+return [
+    /*
+     | The Rich Text model used for the rich text relationships.
+     */
+    'model' => \Tonysm\RichTextLaravel\Models\RichText::class,
 ];

--- a/database/migrations/create_rich_texts_table.php.stub
+++ b/database/migrations/create_rich_texts_table.php.stub
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('rich_texts', function (Blueprint $table) {
+            $table->id();
+            $table->string('field');
+            $table->morphs('record');
+            $table->longText('body');
+            $table->timestamps();
+
+            $table->unique(['field', 'record_type', 'record_id']);
+        });
+    }
+};

--- a/src/Casts/ForwardsAttributeToRelationship.php
+++ b/src/Casts/ForwardsAttributeToRelationship.php
@@ -17,7 +17,15 @@ class ForwardsAttributeToRelationship implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        // dd($model, $key, $value);
+        if (is_string($value)) {
+            $relationship = $model::fieldToRichTextRelationship($key);
+
+            $richText = $model->{$relationship}()->firstOrNew(['field' => $key], [
+                'body' => $value,
+            ]);
+
+            $model->setRelation($relationship, $richText);
+        }
 
         return [];
     }
@@ -33,5 +41,8 @@ class ForwardsAttributeToRelationship implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
+        $relationship = $model::fieldToRichTextRelationship($key);
+
+        return $model->{$relationship};
     }
 }

--- a/src/Casts/ForwardsAttributeToRelationship.php
+++ b/src/Casts/ForwardsAttributeToRelationship.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tonysm\RichTextLaravel\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class ForwardsAttributeToRelationship implements CastsAttributes
+{
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        // dd($model, $key, $value);
+
+        return [];
+    }
+
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+    }
+}

--- a/src/Exceptions/RichTextException.php
+++ b/src/Exceptions/RichTextException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tonysm\RichTextLaravel\Exceptions;
+
+use RuntimeException;
+
+class RichTextException extends RuntimeException
+{
+    public static function missingRichTextFieldsProperty(string $class)
+    {
+        return new static(sprintf(
+            'Missing protecetd property $richTextFields in the %s model.',
+            $class,
+        ));
+    }
+
+    public static function unknownRichTextFieldOnEagerLoading(string $field)
+    {
+        return new static(sprintf('Unknown rich text field: %s.', $field));
+    }
+}

--- a/src/Models/RichText.php
+++ b/src/Models/RichText.php
@@ -17,4 +17,18 @@ class RichText extends Model
     protected $casts = [
         'body' => AsRichTextContent::class,
     ];
+
+    public function record()
+    {
+        return $this->morphTo();
+    }
+
+    public function __call($method, $arguments)
+    {
+        if (method_exists($this->body, $method)) {
+            return call_user_func([$this->body, $method], ...$arguments);
+        }
+
+        return parent::__call($method, $arguments);
+    }
 }

--- a/src/Models/RichText.php
+++ b/src/Models/RichText.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tonysm\RichTextLaravel\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Tonysm\RichTextLaravel\Casts\AsRichTextContent;
+
+class RichText extends Model
+{
+    protected $table = 'rich_texts';
+
+    protected $fillable = [
+        'field',
+        'body',
+    ];
+
+    protected $casts = [
+        'body' => AsRichTextContent::class,
+    ];
+}

--- a/src/Models/RichText.php
+++ b/src/Models/RichText.php
@@ -31,4 +31,9 @@ class RichText extends Model
 
         return parent::__call($method, $arguments);
     }
+
+    public function __toString(): string
+    {
+        return $this->body->render();
+    }
 }

--- a/src/Models/Traits/HasRichText.php
+++ b/src/Models/Traits/HasRichText.php
@@ -6,8 +6,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use RuntimeException;
 use Tonysm\RichTextLaravel\Casts\ForwardsAttributeToRelationship;
+use Tonysm\RichTextLaravel\Exceptions\RichTextException;
 
 trait HasRichText
 {
@@ -50,7 +50,7 @@ trait HasRichText
     protected function getRichTextFields(): array
     {
         if (! property_exists($this, 'richTextFields')) {
-            throw new RuntimeException(sprintf('Missing protected property $richTextFields in %s model.', static::class));
+            throw RichTextException::missingRichTextFieldsProperty(static::class);
         }
 
         return Arr::wrap($this->richTextFields);
@@ -73,7 +73,7 @@ trait HasRichText
         // fields is not a valid one, we'll throw an exception and halt.
 
         $fields = collect($fields)
-            ->each(fn ($field) => throw_unless(in_array($field, $allFields), new RuntimeException(sprintf('Unknown rich text field: %s.', $field))))
+            ->each(fn ($field) => throw_unless(in_array($field, $allFields), RichTextException::unknownRichTextFieldOnEagerLoading($field)))
             ->map(fn ($field) => static::fieldToRichTextRelationship($field))
             ->all();
 

--- a/src/Models/Traits/HasRichText.php
+++ b/src/Models/Traits/HasRichText.php
@@ -18,6 +18,17 @@ trait HasRichText
         foreach ($fields as $field) {
             static::registerRichTextRelationships($field);
         }
+
+        static::saved(function (Model $model) {
+            foreach ($model->getRichTextFields() as $field) {
+                $relationship = static::fieldToRichTextRelationship($field);
+
+                if ($model->relationLoaded($relationship) && $model->{$relationship}->isDirty()) {
+                    $model->{$relationship}->record()->associate($model);
+                    $model->{$relationship}->save();
+                }
+            }
+        });
     }
 
     protected static function registerRichTextRelationships(string $field): void
@@ -45,7 +56,7 @@ trait HasRichText
         return Arr::wrap($this->richTextFields);
     }
 
-    public static function fieldToRichTextRelationship(string $field)
+    public static function fieldToRichTextRelationship(string $field): string
     {
         return 'richText' . Str::studly($field);
     }

--- a/src/Models/Traits/HasRichText.php
+++ b/src/Models/Traits/HasRichText.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tonysm\RichTextLaravel\Models\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Tonysm\RichTextLaravel\Casts\ForwardsAttributeToRelationship;
+use Tonysm\RichTextLaravel\Models\RichText;
+
+trait HasRichText
+{
+    protected static function bootHasRichText()
+    {
+        $fields = (new static)->getRichTextFields();
+
+        foreach ($fields as $field) {
+            static::registerRichTextRelationships($field);
+        }
+    }
+
+    protected static function registerRichTextRelationships(string $field): void
+    {
+        static::resolveRelationUsing(static::fieldToRichTextRelationship($field), function (Model $model) use ($field) {
+            return $model->morphOne(RichText::class, 'record')->where('field', $field);
+        });
+    }
+
+    protected function initializeHasRichText()
+    {
+        foreach ($this->getRichTextFields() as $field) {
+            $this->mergeCasts([
+                $field => ForwardsAttributeToRelationship::class,
+            ]);
+        }
+    }
+
+    protected function getRichTextFields(): array
+    {
+        if (! property_exists($this, 'richTextFields')) {
+            throw new RuntimeException(sprintf('Missing protected property $richTextFields in %s model.', static::class));
+        }
+
+        return Arr::wrap($this->richTextFields);
+    }
+
+    public static function fieldToRichTextRelationship(string $field)
+    {
+        return 'richText' . Str::studly($field);
+    }
+}

--- a/src/Models/Traits/HasRichText.php
+++ b/src/Models/Traits/HasRichText.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use RuntimeException;
 use Tonysm\RichTextLaravel\Casts\ForwardsAttributeToRelationship;
-use Tonysm\RichTextLaravel\Models\RichText;
 
 trait HasRichText
 {
@@ -35,7 +34,7 @@ trait HasRichText
     protected static function registerRichTextRelationships(string $field): void
     {
         static::resolveRelationUsing(static::fieldToRichTextRelationship($field), function (Model $model) use ($field) {
-            return $model->morphOne(RichText::class, 'record')->where('field', $field);
+            return $model->morphOne(config('rich-text-laravel.model'), 'record')->where('field', $field);
         });
     }
 

--- a/src/RichTextLaravelServiceProvider.php
+++ b/src/RichTextLaravelServiceProvider.php
@@ -19,7 +19,7 @@ class RichTextLaravelServiceProvider extends PackageServiceProvider
             ->name('rich-text-laravel')
             ->hasConfigFile()
             ->hasViews()
-            // ->hasMigration('create_rich-text-laravel_table')
+            ->hasMigration('create_rich_texts_table')
             ->hasCommand(RichTextLaravelInstallCommand::class);
     }
 }

--- a/tests/RichTextModelTest.php
+++ b/tests/RichTextModelTest.php
@@ -112,6 +112,41 @@ class RichTextModelTest extends TestCase
         Post::withRichText(['unkown'])->get();
     }
 
+    /** @test */
+    public function can_have_different_fields_on_the_same_model()
+    {
+        $post = Post::create([
+            'body' => '<h1>hello from body</h1>',
+            'notes' => '<h1>hello from notes</h1>',
+        ]);
+
+        $expectedBodyContent = <<<HTML
+        <div class="trix-content">
+            <h1>hello from body</h1>
+        </div>
+
+        HTML;
+
+        $expectedNotesContent = <<<HTML
+        <div class="trix-content">
+            <h1>hello from notes</h1>
+        </div>
+
+        HTML;
+
+        $this->assertEquals($expectedNotesContent, "$post->notes");
+        $this->assertEquals($expectedBodyContent, "$post->body");
+        $this->assertEquals($expectedNotesContent, "$post->richTextNotes");
+        $this->assertEquals($expectedBodyContent, "$post->richTextBody");
+
+        $post->refresh();
+
+        $this->assertEquals($expectedNotesContent, "$post->notes");
+        $this->assertEquals($expectedBodyContent, "$post->body");
+        $this->assertEquals($expectedNotesContent, "$post->richTextNotes");
+        $this->assertEquals($expectedBodyContent, "$post->richTextBody");
+    }
+
     private function createPost(): Post
     {
         return Post::create(['body' => $this->content()]);

--- a/tests/RichTextModelTest.php
+++ b/tests/RichTextModelTest.php
@@ -43,8 +43,12 @@ class RichTextModelTest extends TestCase
     }
 
     /** @test */
-    public function body_field_in_the_rich_text_model_gets_cast_to_rich_text()
+    public function fowards_calls_to_relationship()
     {
+        $post = $this->createPost();
+
+        $this->assertCount(1, $post->body->attachments());
+        $this->assertEquals($this->content(), $post->body->toTrixHtml());
     }
 
     private function createPost(): Post
@@ -56,10 +60,7 @@ class RichTextModelTest extends TestCase
     {
         return <<<HTML
         <h1>Hey, there</h1>
-        <figure
-            data-trix-attachment='{"contentType": "image/png", "width": 200, "height": 100, "url": "http://example.com/red-1.png", "filename": "red-1.png", "filesize": 100}'
-            data-trix-attributes='{"presentation": "gallery", "caption": "Captioned"}'
-        ></figure>
+        <figure data-trix-attachment='{"contentType":"image\/png","url":"http:\/\/example.com\/red-1.png","filename":"red-1.png","filesize":100,"width":200,"height":100}' data-trix-attributes='{"presentation":"gallery","caption":"Captioned"}'></figure>
         HTML;
     }
 }

--- a/tests/RichTextModelTest.php
+++ b/tests/RichTextModelTest.php
@@ -99,8 +99,16 @@ class RichTextModelTest extends TestCase
 
         $queryCounts = 0;
 
-        // With eager loading...
-        Post::withRichText()->get()->each(fn ($post) => $post->body);
+        // The Post model has 2 rich text fields, which means 2 relationships, so eager
+        // loading all fields will result in one query for each relationship. Which,
+        // for us, it means 1 query for the posts, and 1 for each relationship.
+        Post::withRichText()->get()->each(fn ($post) => $post->body && $post->notes);
+        $this->assertEquals(3, $queryCounts);
+
+        $queryCounts = 0;
+
+        // Eager loading only one field will only load that specific field's relationship...
+        Post::withRichText('body')->get()->each(fn ($post) => $post->body);
         $this->assertEquals(2, $queryCounts);
     }
 

--- a/tests/RichTextModelTest.php
+++ b/tests/RichTextModelTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tonysm\RichTextLaravel\Tests;
+
+use Tonysm\RichTextLaravel\Content;
+use Tonysm\RichTextLaravel\Tests\Stubs\HasRichText\Post;
+
+class RichTextModelTest extends TestCase
+{
+    /** @test */
+    public function traits_sets_up_relationship()
+    {
+        $model = Post::create();
+
+        $this->assertNull($model->richTextBody);
+
+        $richText = $model->richTextBody()->create([
+            'field' => 'body',
+            'body' => $this->content(),
+        ]);
+
+        $this->assertNotNull($model->refresh()->richTextBody);
+        $this->assertTrue($model->richTextBody->is($richText));
+        $this->assertInstanceOf(Content::class, $richText->body, 'Expected the body field on the RichText model to be cast to a Content instance, but it was not.');
+    }
+
+    private function content(): string
+    {
+        return <<<HTML
+        <h1>Hey, there</h1>
+        <figure
+            data-trix-attachment='{"contentType": "image/png", "width": 200, "height": 100, "url": "http://example.com/red-1.png", "filename": "red-1.png", "filesize": 100}'
+            data-trix-attributes='{"presentation": "gallery", "caption": "Captioned"}'
+        ></figure>
+        HTML;
+    }
+}

--- a/tests/RichTextModelTest.php
+++ b/tests/RichTextModelTest.php
@@ -3,6 +3,7 @@
 namespace Tonysm\RichTextLaravel\Tests;
 
 use Tonysm\RichTextLaravel\Content;
+use Tonysm\RichTextLaravel\Models\RichText;
 use Tonysm\RichTextLaravel\Tests\Stubs\HasRichText\Post;
 
 class RichTextModelTest extends TestCase
@@ -22,6 +23,33 @@ class RichTextModelTest extends TestCase
         $this->assertNotNull($model->refresh()->richTextBody);
         $this->assertTrue($model->richTextBody->is($richText));
         $this->assertInstanceOf(Content::class, $richText->body, 'Expected the body field on the RichText model to be cast to a Content instance, but it was not.');
+        $this->assertTrue($model->richTextBody->record->is($model));
+    }
+
+    /** @test */
+    public function forwards_attribute_mutators_and_accessors_to_relationship()
+    {
+        $post = $this->createPost();
+
+        $this->assertInstanceOf(RichText::class, $post->body);
+        $this->assertTrue($post->relationLoaded('richTextBody'), 'Expected the richTextBody relationship to be loaded, but it was not.');
+        $this->assertNotEmpty($post->richTextBody->body->raw());
+        $this->assertTrue($post->richTextBody->is($post->body));
+
+        $this->assertTrue($post->body->exists, 'RichText model was not saved with the parent model.');
+
+        $this->assertInstanceOf(RichText::class, $post->refresh()->body, 'RichText model reference was lost after the parent model was refreshed.');
+        $this->assertNotEmpty($post->body->raw());
+    }
+
+    /** @test */
+    public function body_field_in_the_rich_text_model_gets_cast_to_rich_text()
+    {
+    }
+
+    private function createPost(): Post
+    {
+        return Post::create(['body' => $this->content()]);
     }
 
     private function content(): string

--- a/tests/RichTextModelTest.php
+++ b/tests/RichTextModelTest.php
@@ -51,6 +51,34 @@ class RichTextModelTest extends TestCase
         $this->assertEquals($this->content(), $post->body->toTrixHtml());
     }
 
+    /** @test */
+    public function renders_to_text()
+    {
+        $post = $this->createPost();
+
+        $expectedRender = <<<HTML
+        <div class="trix-content">
+            <h1>Hey, there</h1>
+        <figure class="attachment attachment--preview attachment--png">
+            <img src="http://example.com/red-1.png" width="200" height="100">
+            <figcaption class="attachment__caption">
+                Captioned
+            </figcaption>
+        </figure>
+
+        </div>
+
+        HTML;
+
+        $this->assertEquals($expectedRender, "$post->body");
+        $this->assertEquals($expectedRender, "$post->richTextBody");
+
+        $post->refresh();
+
+        $this->assertEquals($expectedRender, "$post->body");
+        $this->assertEquals($expectedRender, "$post->richTextBody");
+    }
+
     private function createPost(): Post
     {
         return Post::create(['body' => $this->content()]);

--- a/tests/RichTextModelTest.php
+++ b/tests/RichTextModelTest.php
@@ -3,8 +3,8 @@
 namespace Tonysm\RichTextLaravel\Tests;
 
 use Illuminate\Support\Facades\DB;
-use RuntimeException;
 use Tonysm\RichTextLaravel\Content;
+use Tonysm\RichTextLaravel\Exceptions\RichTextException;
 use Tonysm\RichTextLaravel\Models\RichText;
 use Tonysm\RichTextLaravel\Tests\Stubs\HasRichText\Post;
 
@@ -126,7 +126,7 @@ class RichTextModelTest extends TestCase
     /** @test */
     public function throws_exception_when_eager_loading_unkown_rich_text_field()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(RichTextException::class);
 
         Post::withRichText(['unkown'])->get();
     }

--- a/tests/Stubs/HasRichText/Post.php
+++ b/tests/Stubs/HasRichText/Post.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tonysm\RichTextLaravel\Tests\Stubs\HasRichText;
+
+use Illuminate\Database\Eloquent\Model;
+use Tonysm\RichTextLaravel\Models\Traits\HasRichText;
+
+class Post extends Model
+{
+    use HasRichText;
+
+    protected $guarded = [];
+
+    protected $richTextFields = [
+        'body',
+    ];
+}

--- a/tests/Stubs/HasRichText/Post.php
+++ b/tests/Stubs/HasRichText/Post.php
@@ -13,5 +13,6 @@ class Post extends Model
 
     protected $richTextFields = [
         'body',
+        'notes',
     ];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,7 +53,7 @@ class TestCase extends Orchestra
             $table->timestamps();
         });
 
-        $migration = require_once __DIR__.'/../database/migrations/create_rich_texts_table.php.stub';
+        $migration = require __DIR__.'/../database/migrations/create_rich_texts_table.php.stub';
         $migration->up();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -52,5 +52,8 @@ class TestCase extends Orchestra
             $table->string('name');
             $table->timestamps();
         });
+
+        $migration = require_once __DIR__.'/../database/migrations/create_rich_texts_table.php.stub';
+        $migration->up();
     }
 }


### PR DESCRIPTION
### Added

- Implements the RichText model with a virtual field. It seems to work as stated in the RFC. We add the `HasRichText` trait to the model we want to have rich text fields and then specify which fields in the `protected $richTextFields`. There is a custom cast that forwards calls to the relationship (see the `ForwardsAttributeToRelationship`). This custom cast is added to the list of casters in the model using the `initialize{Trait}` method (see the `HasRichText::initializeHasRichText`), which should be called whenever an Eloquent model using the trait is instantiated.
- There is a `withRichText()` scope that can eager load the rich text fields. By default, it will eager-load all rich text fields specified in the `$richTextFields`. It accepts an optional list of fields, which you can specify as a singular field or an array of fields, like so `::withRichText('body')` or `::withRichText(['body', 'notes'])`.
- Documentation

---

To better understand how this all works, I recommend checking out the `RichTextModelTest` file and reading the RFC referenced below.

Hat tip to @damiani and @sbine for the insights.

---

Check the RFC for reference: https://github.com/tonysm/rich-text-laravel/issues/6