### PR TITLE
Attachables Getter and Attachment Rendering

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -99,6 +99,11 @@ class Attachment
         return $this->caption() ?: '';
     }
 
+    public function toHtml(): string
+    {
+        return HtmlConversion::nodeElementToHtml($this->node);
+    }
+
     public function fullAttributes(): Collection
     {
         return $this->nodeAttributes()
@@ -133,6 +138,11 @@ class Attachment
     public function is(Attachment $attachment): bool
     {
         return $this->attachable->equalsToAttachable($attachment->attachable);
+    }
+
+    public function __toString()
+    {
+        return $this->toHtml();
     }
 
     public function __call($method, $arguments)

--- a/src/Content.php
+++ b/src/Content.php
@@ -69,6 +69,13 @@ class Content
         ));
     }
 
+    public function attachables(): Collection
+    {
+        return $this->cachedAttachables ??= $this->attachmentNodes()->map(fn (DOMElement $node) => (
+            AttachableFactory::fromNode($node)
+        ));
+    }
+
     public function galleryAttachments(): Collection
     {
         return $this->cachedGalleryAttachments ??= $this->attachmentGalleries()->flatMap(fn (AttachmentGallery $attachmentGallery) => $attachmentGallery->attachments());

--- a/src/Content.php
+++ b/src/Content.php
@@ -17,6 +17,7 @@ class Content
     private $cachedAttachmentGalleries;
     private $cachedAttachmentGalleryNodes;
     private $cachedGalleryAttachments;
+    private $cachedAttachables;
 
     public static function fromStorage(?string $value = null): self
     {

--- a/src/HtmlConversion.php
+++ b/src/HtmlConversion.php
@@ -7,6 +7,11 @@ use DOMElement;
 
 class HtmlConversion
 {
+    public static function nodeElementToHtml(DOMElement $node): string
+    {
+        return $node->ownerDocument->saveHTML($node);
+    }
+
     public static function nodeToHtml(DOMDocument $node): string
     {
         return preg_replace("#</?rich-text-root>\n*#", "", $node->saveHTML($node->documentElement));

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -69,6 +69,18 @@ class AttachmentTest extends TestCase
     }
 
     /** @test */
+    public function converst_to_html()
+    {
+        $attachment = Attachment::fromAttachable($this->attachable(), ['caption' => 'hey, there']);
+        $this->assertEquals('<rich-text-attachment caption="hey, there" sgid="eyJzZ2lkIjoiZ2lkOlwvXC9yaWNoLXRleHQtbGFyYXZlbFwvVG9ueXNtJTVDUmljaFRleHRMYXJhdmVsJTVDVGVzdHMlNUNTdHVicyU1Q1VzZXJcLzEiLCJwdXJwb3NlIjoicmljaC10ZXh0LWxhcmF2ZWwiLCJleHBpcmVzX2F0IjpudWxsfQ==--3442b51e2f1b56d5928b4654847c19e4d4b03f57dcfa02bcd6cbdc01ccec004c" content-type="application/octet-stream"></rich-text-attachment>', $attachment->toHtml());
+        $this->assertEquals('<rich-text-attachment caption="hey, there" sgid="eyJzZ2lkIjoiZ2lkOlwvXC9yaWNoLXRleHQtbGFyYXZlbFwvVG9ueXNtJTVDUmljaFRleHRMYXJhdmVsJTVDVGVzdHMlNUNTdHVicyU1Q1VzZXJcLzEiLCJwdXJwb3NlIjoicmljaC10ZXh0LWxhcmF2ZWwiLCJleHBpcmVzX2F0IjpudWxsfQ==--3442b51e2f1b56d5928b4654847c19e4d4b03f57dcfa02bcd6cbdc01ccec004c" content-type="application/octet-stream"></rich-text-attachment>', (string)$attachment);
+
+        $attachment = Attachment::fromAttachable(User::create(['name' => 'hey']));
+        $this->assertEquals('<rich-text-attachment sgid="eyJzZ2lkIjoiZ2lkOlwvXC9yaWNoLXRleHQtbGFyYXZlbFwvVG9ueXNtJTVDUmljaFRleHRMYXJhdmVsJTVDVGVzdHMlNUNTdHVicyU1Q1VzZXJcLzIiLCJwdXJwb3NlIjoicmljaC10ZXh0LWxhcmF2ZWwiLCJleHBpcmVzX2F0IjpudWxsfQ==--e260941c7b4f1875c536edf100274fbb3c4c8e3a1b41afd00efa16cf258a1982" content-type="application/octet-stream"></rich-text-attachment>', $attachment->toHtml());
+        $this->assertEquals('<rich-text-attachment sgid="eyJzZ2lkIjoiZ2lkOlwvXC9yaWNoLXRleHQtbGFyYXZlbFwvVG9ueXNtJTVDUmljaFRleHRMYXJhdmVsJTVDVGVzdHMlNUNTdHVicyU1Q1VzZXJcLzIiLCJwdXJwb3NlIjoicmljaC10ZXh0LWxhcmF2ZWwiLCJleHBpcmVzX2F0IjpudWxsfQ==--e260941c7b4f1875c536edf100274fbb3c4c8e3a1b41afd00efa16cf258a1982" content-type="application/octet-stream"></rich-text-attachment>', (string)$attachment);
+    }
+
+    /** @test */
     public function converst_to_plain_text()
     {
         $attachment = Attachment::fromAttachable($this->attachable(), ['caption' => 'hey, there']);

--- a/tests/ContentTest.php
+++ b/tests/ContentTest.php
@@ -54,7 +54,7 @@ class ContentTest extends TestCase
     }
 
     /** @test */
-    public function extracts_attachables()
+    public function extracts_attachments()
     {
         $attachable = User::create(['name' => 'Jon Doe']);
         $sgid = $attachable->richTextSgid();
@@ -71,6 +71,26 @@ class ContentTest extends TestCase
 
         $this->assertEquals("Captioned", $attachment->caption());
         $this->assertTrue($attachment->attachable->is($attachable));
+    }
+
+    /** @test */
+    public function extracts_attachables()
+    {
+        $attachable = User::create(['name' => 'Jon Doe']);
+        $sgid = $attachable->richTextSgid();
+
+        $html = <<<HTML
+        <rich-text-attachment sgid="$sgid" trix-attributes="{'caption': 'Captioned"></rich-text-attachment>
+        HTML;
+
+        $content = $this->fromHtml($html);
+
+        $this->assertCount(1, $content->attachables());
+
+        $extractedAttachable = $content->attachables()->first();
+
+        $this->assertNotNull($extractedAttachable);
+        $this->assertTrue($extractedAttachable->is($attachable));
     }
 
     /** @test */


### PR DESCRIPTION
### Added

- Adds an `Content::attachables()` method that returns a collection with all the attachables in the rich text document. This was previously possible with something like `$message->content->attachments()->pluck('attachable')`, but now it's much simpler: `$message->content->attachables()`
- Adds a `Attachment::toHtml(): string` method, which allows rendering any attachment right away. Useful when you're trying to parse the document and replace some patterns with attachables in the backend (see code below)

---

The example of how we can use the `toHtml()` method:

```php
class Message extends Model
{
  public static function booted()
  {
    static::creating(function (Message $message) {
      // Scan the document looking for @-mentions and replace them
      // with a `<rich-text-attachment>` for the mentioned user...

      $message->content = preg_replace_callback(
        '/\B\@(\w+)/',
        function ($matches) {
          if ($user = User::where('username', $matches[1])->first()) {
            return Attachment::fromAttachable($user)->toHtml();
          }

          return $matches[0];
        },
        $message->content->toHtml(),
      );
    });
  }
}