### PR TITLE
Fix Livewire issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,71 @@ When storing references of custom attachments, the package uses another package 
 
 In case you want to rotate your key, you would need to loop-through all the rich text content, take all attachables with an `sgid` attribute, assign a new value to it with the new signature using the new secret, and store the content with that new value.
 
+
+
+### Livewire
+
+If you're binding a model that has rich text fields to a Livewire component, you may add the `WithRichTexts` trait to your component. Also, it's recommended that you keep the rich text in raw form until the moment you want to save that to the Rich Text field, something like this:
+
+```php
+<?php
+
+namespace App\Http\Livewire;
+
+use App\Models\User;
+use Livewire\Component;
+use Tonysm\RichTextLaravel\Livewire\WithRichTexts;
+
+class UserProfileForm extends Component
+{
+    use WithRichTexts;
+
+    public User $user;
+    public $bio = '';
+
+    protected $rules = [
+        'bio' => ['required'],
+    ];
+
+    public function mount(User $user)
+    {
+        $this->user = $user;
+        $this->bio = $user->bio->toTrixHtml();
+    }
+
+    public function save()
+    {
+        $this->validate();
+
+        $this->user->update([
+            'bio' => $this->bio,
+        ]);
+    }
+}
+```
+
+In this example, the User model has a `bio` rich text field.
+
+<details>
+<summary>See the contents of the User model in the example</summary>
+
+```php
+<?php
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Tonysm\RichTextLaravel\Models\Traits\HasRichText;
+
+class User extends Model
+{
+    use HasRichText;
+
+    protected $fillable = ['bio'];
+    protected $richTextFields = ['bio'];
+}
+```
+
+</details>
+
 ## Testing
 
 ```bash

--- a/src/Livewire/WithRichTexts.php
+++ b/src/Livewire/WithRichTexts.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tonysm\RichTextLaravel\Livewire;
+
+trait WithRichTexts
+{
+
+}

--- a/src/Livewire/WithRichTexts.php
+++ b/src/Livewire/WithRichTexts.php
@@ -4,5 +4,4 @@ namespace Tonysm\RichTextLaravel\Livewire;
 
 trait WithRichTexts
 {
-
 }

--- a/src/LivewireSupportsRichText.php
+++ b/src/LivewireSupportsRichText.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tonysm\RichTextLaravel;
+
+use Livewire\Livewire;
+use Tonysm\RichTextLaravel\Livewire\WithRichTexts;
+use Tonysm\RichTextLaravel\Models\Traits\HasRichText;
+
+class LivewireSupportsRichText
+{
+    static function init() { new static; }
+
+    function __construct()
+    {
+        if (! class_exists(Livewire::class)) return;
+
+        Livewire::listen('property.dehydrate', function ($property, $value, $component, $response) {
+            $uses = array_flip(class_uses_recursive($component));
+
+            if (! in_array(WithRichTexts::class, $uses)) return;
+
+            $this->dehydratePropertyFromWithRichText($value);
+        });
+    }
+
+    protected function dehydratePropertyFromWithRichText($value)
+    {
+        if (! is_object($value)) return;
+
+        $uses = array_flip(class_uses_recursive($value));
+
+        if (! in_array(HasRichText::class, $uses)) return;
+
+        $value->unsetRelationshipsForLivewireDehydration();
+    }
+}

--- a/src/LivewireSupportsRichText.php
+++ b/src/LivewireSupportsRichText.php
@@ -42,6 +42,6 @@ class LivewireSupportsRichText
             return;
         }
 
-        $value->unsetRelationshipsForLivewireDehydration();
+        $value->unsetRichTextRelationshipsForLivewireDehydration();
     }
 }

--- a/src/LivewireSupportsRichText.php
+++ b/src/LivewireSupportsRichText.php
@@ -8,16 +8,23 @@ use Tonysm\RichTextLaravel\Models\Traits\HasRichText;
 
 class LivewireSupportsRichText
 {
-    static function init() { new static; }
-
-    function __construct()
+    public static function init()
     {
-        if (! class_exists(Livewire::class)) return;
+        new static;
+    }
+
+    public function __construct()
+    {
+        if (! class_exists(Livewire::class)) {
+            return;
+        }
 
         Livewire::listen('property.dehydrate', function ($property, $value, $component, $response) {
             $uses = array_flip(class_uses_recursive($component));
 
-            if (! in_array(WithRichTexts::class, $uses)) return;
+            if (! in_array(WithRichTexts::class, $uses)) {
+                return;
+            }
 
             $this->dehydratePropertyFromWithRichText($value);
         });
@@ -25,11 +32,15 @@ class LivewireSupportsRichText
 
     protected function dehydratePropertyFromWithRichText($value)
     {
-        if (! is_object($value)) return;
+        if (! is_object($value)) {
+            return;
+        }
 
         $uses = array_flip(class_uses_recursive($value));
 
-        if (! in_array(HasRichText::class, $uses)) return;
+        if (! in_array(HasRichText::class, $uses)) {
+            return;
+        }
 
         $value->unsetRelationshipsForLivewireDehydration();
     }

--- a/src/Models/Traits/HasRichText.php
+++ b/src/Models/Traits/HasRichText.php
@@ -3,11 +3,9 @@
 namespace Tonysm\RichTextLaravel\Models\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Livewire\Livewire;
 use Tonysm\RichTextLaravel\Casts\ForwardsAttributeToRelationship;
 use Tonysm\RichTextLaravel\Exceptions\RichTextException;
 
@@ -31,26 +29,9 @@ trait HasRichText
                 }
             }
         });
-
-        if (class_exists(Livewire::class)) {
-            Livewire::listen('component.dehydrate', function (\Livewire\Component $instance) {
-                foreach ($instance->getPublicPropertiesDefinedBySubClass() as $value) {
-                    static::unsetRichTextRelationshipsOn($value);
-                }
-            });
-        }
     }
 
-    protected static function unsetRichTextRelationshipsOn($value)
-    {
-        if ($value instanceof static) {
-            $value->unsetRichTextRelationships();
-        } elseif ($value instanceof Collection) {
-            $value->each(fn ($each) => static::unsetRichTextRelationshipsOn($each));
-        }
-    }
-
-    protected function unsetRichTextRelationships()
+    public function unsetRelationshipsForLivewireDehydration()
     {
         $relationships = array_map(fn ($field) => static::fieldToRichTextRelationship($field), $this->getRichTextFields());
 

--- a/src/Models/Traits/HasRichText.php
+++ b/src/Models/Traits/HasRichText.php
@@ -31,7 +31,7 @@ trait HasRichText
         });
     }
 
-    public function unsetRelationshipsForLivewireDehydration()
+    public function unsetRichTextRelationshipsForLivewireDehydration()
     {
         $relationships = array_map(fn ($field) => static::fieldToRichTextRelationship($field), $this->getRichTextFields());
 

--- a/src/RichTextLaravelServiceProvider.php
+++ b/src/RichTextLaravelServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Tonysm\RichTextLaravel;
 
-use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Tonysm\RichTextLaravel\Commands\RichTextLaravelInstallCommand;
@@ -22,5 +21,10 @@ class RichTextLaravelServiceProvider extends PackageServiceProvider
             ->hasViews()
             ->hasMigration('create_rich_texts_table')
             ->hasCommand(RichTextLaravelInstallCommand::class);
+    }
+
+    public function packageBooted()
+    {
+        LivewireSupportsRichText::init();
     }
 }

--- a/src/RichTextLaravelServiceProvider.php
+++ b/src/RichTextLaravelServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Tonysm\RichTextLaravel;
 
+use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Tonysm\RichTextLaravel\Commands\RichTextLaravelInstallCommand;


### PR DESCRIPTION
### Fixed

- Unset the RichText fields relationships on models bound to a Livewire component.

---

I've noticed that when the RichText model is present in a model's `$relationships` when that model is bound to a Livewire component breaks the dehydration of the component. I don't fully understand why that is (maybe it's because the RichText model overrides the `__call` method? Even though it passes it up again.) But it looks like unsettling the rich text relationships when the component is dehydration fixes the issue.