### PR TITLE
Fix should not touch records timestamp when touching is disabled

### DIFF
--- a/src/Models/Traits/HasRichText.php
+++ b/src/Models/Traits/HasRichText.php
@@ -20,11 +20,13 @@ trait HasRichText
         }
 
         static::saving(function (Model $model) {
-            foreach ($model->getRichTextFields() as $field => $_options) {
-                $relationship = static::fieldToRichTextRelationship($field);
+            if (! $model::isIgnoringTouch()) {
+                foreach ($model->getRichTextFields() as $field => $_options) {
+                    $relationship = static::fieldToRichTextRelationship($field);
 
-                if ($model->relationLoaded($relationship) && $model->{$field}->isDirty() && $model->timestamps) {
-                    $model->updateTimestamps();
+                    if ($model->relationLoaded($relationship) && $model->{$field}->isDirty() && $model->timestamps) {
+                        $model->updateTimestamps();
+                    }
                 }
             }
         });

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -2,6 +2,8 @@
 
 namespace Tonysm\RichTextLaravel\Tests;
 
+use Illuminate\Database\Eloquent\Model;
+use Workbench\App\Models\Post;
 use Workbench\Database\Factories\PostFactory;
 
 class ModelTest extends TestCase
@@ -116,5 +118,41 @@ class ModelTest extends TestCase
         ]);
 
         $this->assertTrue($post->created_at->eq($post->updated_at), 'Record timestamps were touched, but it shouldnt.');
+    }
+
+    /** @test */
+    public function doesnt_touch_record_when_touching_is_disabled_on_the_specific_model()
+    {
+        $this->freezeTime();
+
+        $post = PostFactory::new()->create([
+            'body' => '<h1>Old Value</h1>',
+        ])->fresh();
+
+        $this->travel(5)->minutes();
+
+        Post::withoutTouching(fn () => $post->update([
+            'body' => '<h1>New Value</h1>',
+        ]));
+
+        $this->assertTrue($post->refresh()->created_at->eq($post->refresh()->updated_at), 'Record timestamps were touched, but it shouldnt.');
+    }
+
+    /** @test */
+    public function doesnt_touch_record_when_touching_is_disabled_globally()
+    {
+        $this->freezeTime();
+
+        $post = PostFactory::new()->create([
+            'body' => '<h1>Old Value</h1>',
+        ])->fresh();
+
+        $this->travel(5)->minutes();
+
+        Model::withoutTouching(fn () => $post->update([
+            'body' => '<h1>New Value</h1>',
+        ]));
+
+        $this->assertTrue($post->refresh()->created_at->eq($post->refresh()->updated_at), 'Record timestamps were touched, but it shouldnt.');
     }
 }


### PR DESCRIPTION
### Fixed

- We shouldn't update the record's timestamp when model touching is disabled (either globally or only for the current model)

---

closes https://github.com/tonysm/rich-text-laravel/issues/48