### PR TITLE
Allow configuring the encryption handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,25 @@ class Post extends Model
 }
 ```
 
-This uses [Laravel's Encryption](https://laravel.com/docs/10.x/encryption#introduction) feature.
+This uses [Laravel's Encryption](https://laravel.com/docs/encryption#introduction) feature. By default, it will encrypt using the default encryption handler in Laravel, which serializes the value before encrypting it. However you can opt-in skip the serialization step and only encrypt as string by calling the following method in the `AppServiceProvider`:
+
+```php
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Tonysm\RichTextLaravel\RichTextLaravel;
+
+class AppServiceProvider extends ServiceProvider
+{
+    // ...
+    public function boot(): void
+    {
+        RichTextLaravel::encryptAsString();
+    }
+}
+```
+
+In the next major version of the package, this will be the default, so it's recommended that you do that.
 
 #### Key Rotation
 

--- a/src/Casts/AsEncryptedRichTextContent.php
+++ b/src/Casts/AsEncryptedRichTextContent.php
@@ -4,6 +4,7 @@ namespace Tonysm\RichTextLaravel\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Tonysm\RichTextLaravel\Content;
+use Tonysm\RichTextLaravel\RichTextLaravel;
 
 class AsEncryptedRichTextContent implements CastsAttributes
 {
@@ -18,7 +19,7 @@ class AsEncryptedRichTextContent implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        return encrypt(Content::toStorage($value));
+        return RichTextLaravel::encrypt(Content::toStorage($value), $model, $key);
     }
 
     /**
@@ -32,6 +33,6 @@ class AsEncryptedRichTextContent implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
-        return Content::fromStorage($value ? decrypt($value) : null);
+        return Content::fromStorage(RichTextLaravel::decrypt($value, $model, $key));
     }
 }

--- a/src/RichTextLaravel.php
+++ b/src/RichTextLaravel.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tonysm\RichTextLaravel;
+
+use Illuminate\Support\Facades\Crypt;
+
+class RichTextLaravel
+{
+    /**
+     * The handler responsible for encrypting the rich text attributes.
+     *
+     * @var callable
+     */
+    protected static $encryptHandler;
+
+    /**
+     * The handle responsible for decrypting the rich text attributes.
+     *
+     * @var callable
+     */
+    protected static $decryptHandler;
+
+    /**
+     * Override the way the package handles encryption.
+     */
+    public static function encryptUsing($encryption, $decryption): void
+    {
+        static::$encryptHandler = $encryption;
+        static::$decryptHandler = $decryption;
+    }
+
+    /**
+     * Configures the Rich Text Laravel package to store encrypted data as string,
+     * instead of using Laravel's default encryption mode, which serializes the
+     * content before encrypting it.
+     */
+    public static function encryptAsString(): void
+    {
+        static::$encryptHandler = fn ($value) => Crypt::encryptString($value);
+        static::$decryptHandler = fn ($value) => ($value ? Crypt::decryptString($value) : $value);
+    }
+
+    public static function clearEncryptionHandlers(): void
+    {
+        static::encryptUsing(null, null);
+    }
+
+    public static function encrypt($value, $model, $key): string
+    {
+        $encrypt = static::$encryptHandler ??= fn ($value) => Crypt::encrypt($value);
+
+        return call_user_func($encrypt, $value, $model, $key);
+    }
+
+    public static function decrypt($value, $model, $key): ?string
+    {
+        $decrypt = static::$decryptHandler ??= fn ($value) => Crypt::decrypt($value);
+
+        return $value ? call_user_func($decrypt, $value, $model, $key) : $value;
+    }
+}

--- a/tests/EncryptedModelTest.php
+++ b/tests/EncryptedModelTest.php
@@ -3,6 +3,7 @@
 namespace Tonysm\RichTextLaravel\Tests;
 
 use Illuminate\Support\Facades\DB;
+use Tonysm\RichTextLaravel\RichTextLaravel;
 use Workbench\App\Models\EncryptedMessage;
 use Workbench\App\Models\Message;
 
@@ -18,10 +19,19 @@ class EncryptedModelTest extends TestCase
         $this->assertNotEncryptedRichTextAttribute($clearMessage, 'content', 'Hello World');
     }
 
+    /** @test */
+    public function encrypts_as_string()
+    {
+        RichTextLaravel::encryptAsString();
+
+        $encryptedMessage = EncryptedMessage::create(['content' => 'Hello World']);
+        $this->assertEncryptedRichTextAttribute($encryptedMessage, 'content', 'Hello World');
+    }
+
     private function assertEncryptedRichTextAttribute($model, $field, $expectedValue)
     {
         $this->assertStringNotContainsString($expectedValue, $encrypted = DB::table('rich_texts')->where('record_id', $model->id)->value('body'));
-        $this->assertEquals($expectedValue, decrypt($encrypted));
+        $this->assertEquals($expectedValue, RichTextLaravel::decrypt($encrypted, $model, $field));
         $this->assertStringContainsString($expectedValue, $model->refresh()->{$field}->body->toHtml());
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Tonysm\RichTextLaravel\RichTextLaravel;
 
 class TestCase extends Orchestra
 {
@@ -19,6 +20,8 @@ class TestCase extends Orchestra
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'Tonysm\\RichTextLaravel\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
+
+        RichTextLaravel::clearEncryptionHandlers();
     }
 
     public function getEnvironmentSetUp($app)


### PR DESCRIPTION
### Changed

- Allows configuring the encryption handles. By default, Laravel's encryption will serialize the value before encrypting. But the preferred way is actually to encrypt it as a string. For BC reasons, I'll introduce this new way of configuring the encryption with a new method to enable storing the encryption as string if you want to. In 2.x, this will be opt-in, but I'll tag 3.x because I want this to be the default way. I'll add some notes on how to migrate the currently encrypted data for folks using this feature in 2.x

---

issue #51 