### PR TITLE
Default to `encryptString` and `decryptString`

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,14 @@ class Post extends Model
 }
 ```
 
-This uses [Laravel's Encryption](https://laravel.com/docs/encryption#introduction) feature. By default, it will encrypt using the default encryption handler in Laravel, which serializes the value before encrypting it. However you can opt-in skip the serialization step and only encrypt as string by calling the following method in the `AppServiceProvider`:
+This uses [Laravel's Encryption](https://laravel.com/docs/encryption#introduction) feature. By default, we'll encrypt using Laravel's `Crypt::encryptString()` and decrypt with `Crypt::decryptString()`. If you're coming from version 2 of the Rich Text Laravel package, which would default to `Crypt::encrypt()` and `Crypt::decrypt()`, you must migrate your data manually (see instructions in the [2.2.0](https://github.com/tonysm/rich-text-laravel/releases/tag/2.2.0) release). This is the recommended way to upgrade to 3.x.
+
+With that being said, you may configure how the package handles encryption however you want to by calling the `RichTextLaravel::encryptUsing()` method on your `AppServiceProvider::boot` method. This method takes an encryption and decryption handler. The handler will receive the value, the model and key (field) that is being encrypted, like so:
 
 ```php
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\ServiceProvider;
 use Tonysm\RichTextLaravel\RichTextLaravel;
 
@@ -205,12 +208,15 @@ class AppServiceProvider extends ServiceProvider
     // ...
     public function boot(): void
     {
-        RichTextLaravel::encryptAsString();
+        RichTextLaravel::encryptUsing(
+            encryption: fn ($value, $model, $key) => Crypt::encrypt($value),
+            decryption: fn ($value, $model, $key) => Crypt::decrypt($value),
+        );
     }
 }
 ```
 
-In the next major version of the package, this will be the default, so it's recommended that you do that.
+Again, it's recommended that you migrate your existing encrypted data and use the default encryption handler (see instructions [here](https://github.com/tonysm/rich-text-laravel/releases/tag/2.2.0)).
 
 #### Key Rotation
 

--- a/src/RichTextLaravel.php
+++ b/src/RichTextLaravel.php
@@ -30,14 +30,11 @@ class RichTextLaravel
     }
 
     /**
-     * Configures the Rich Text Laravel package to store encrypted data as string,
-     * instead of using Laravel's default encryption mode, which serializes the
-     * content before encrypting it.
+     * This will be the default.
      */
     public static function encryptAsString(): void
     {
-        static::$encryptHandler = fn ($value) => Crypt::encryptString($value);
-        static::$decryptHandler = fn ($value) => ($value ? Crypt::decryptString($value) : $value);
+        static::encryptUsing(null, null);
     }
 
     public static function clearEncryptionHandlers(): void
@@ -47,14 +44,14 @@ class RichTextLaravel
 
     public static function encrypt($value, $model, $key): string
     {
-        $encrypt = static::$encryptHandler ??= fn ($value) => Crypt::encrypt($value);
+        $encrypt = static::$encryptHandler ??= fn ($value) => Crypt::encryptString($value);
 
         return call_user_func($encrypt, $value, $model, $key);
     }
 
     public static function decrypt($value, $model, $key): ?string
     {
-        $decrypt = static::$decryptHandler ??= fn ($value) => Crypt::decrypt($value);
+        $decrypt = static::$decryptHandler ??= fn ($value) => Crypt::decryptString($value);
 
         return $value ? call_user_func($decrypt, $value, $model, $key) : $value;
     }

--- a/tests/EncryptedModelTest.php
+++ b/tests/EncryptedModelTest.php
@@ -19,15 +19,6 @@ class EncryptedModelTest extends TestCase
         $this->assertNotEncryptedRichTextAttribute($clearMessage, 'content', 'Hello World');
     }
 
-    /** @test */
-    public function encrypts_as_string()
-    {
-        RichTextLaravel::encryptAsString();
-
-        $encryptedMessage = EncryptedMessage::create(['content' => 'Hello World']);
-        $this->assertEncryptedRichTextAttribute($encryptedMessage, 'content', 'Hello World');
-    }
-
     private function assertEncryptedRichTextAttribute($model, $field, $expectedValue)
     {
         $this->assertStringNotContainsString($expectedValue, $encrypted = DB::table('rich_texts')->where('record_id', $model->id)->value('body'));


### PR DESCRIPTION
### Changed

- Defaults to encrypting and decrypting as strings instead of the default way (which serializes the value before encrypting)


---

closes #52 