### PR TITLE
Support custom content attachments that dont require an sgid

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,10 +401,6 @@ class AppServiceProvider extends ServiceProvider
 This resolver must either return an instance of an `AttachableContract` implementation or `null` if the node doesn't match your attachment. In this case of an `OpengraphEmbed`, this would look something like this:
 
 ```php
-<?php
-
-namespace Workbench\App\Models\Opengraph;
-
 use DOMElement;
 use Tonysm\RichTextLaravel\Attachables\AttachableContract;
 
@@ -425,7 +421,7 @@ class OpengraphEmbed implements AttachableContract
 }
 ```
 
-You can see a full working implementation of this OpenGraph example in the Chat workbench demo (or in [this PR](https://github.com/tonysm/rich-text-laravel/pull/56)).
+You can see a full working implementation of this OpenGraph example in the Chat Workbench demo (or in [this PR](https://github.com/tonysm/rich-text-laravel/pull/56)).
 
 ### Plain Text Rendering
 <a name="plain-text"></a>

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ $post->body->galleryAttachments()
 You may want to attach resources that don't need to be stored in the database. One example of this is perhaps storing the OpenGraph Embed of links in a chat message. You probably don't want to store each OpenGraph Embed as its own database record. For cases like this, where the integraty of the data isn't necessarily key, you may register a custom attachment resolver:
 
 ```php
+use App\Models\Opengraph\OpengraphEmbed;
 use Illuminate\Support\ServiceProvider;
 use Tonysm\RichTextLaravel\RichTextLaravel;
 
@@ -401,6 +402,8 @@ class AppServiceProvider extends ServiceProvider
 This resolver must either return an instance of an `AttachableContract` implementation or `null` if the node doesn't match your attachment. In this case of an `OpengraphEmbed`, this would look something like this:
 
 ```php
+namespace App\Models\Opengraph;
+
 use DOMElement;
 use Tonysm\RichTextLaravel\Attachables\AttachableContract;
 

--- a/src/AttachableFactory.php
+++ b/src/AttachableFactory.php
@@ -12,6 +12,10 @@ class AttachableFactory
 {
     public static function fromNode(DOMElement $node): Attachables\AttachableContract
     {
+        if ($attachable = RichTextLaravel::attachableFromCustomResolver($node)) {
+            return $attachable;
+        }
+
         if ($node->hasAttribute('sgid') && $attachable = static::attachableFromSgid($node->getAttribute('sgid'))) {
             return $attachable;
         }

--- a/src/RichTextLaravel.php
+++ b/src/RichTextLaravel.php
@@ -2,6 +2,7 @@
 
 namespace Tonysm\RichTextLaravel;
 
+use Closure;
 use DOMElement;
 use Illuminate\Support\Facades\Crypt;
 use Tonysm\RichTextLaravel\Attachables\AttachableContract;
@@ -65,7 +66,7 @@ class RichTextLaravel
         return $value ? call_user_func($decrypt, $value, $model, $key) : $value;
     }
 
-    public static function withCustomAttachables($customAttachablesResolver): void
+    public static function withCustomAttachables(Closure|callable|null $customAttachablesResolver): void
     {
         static::$customAttachablesResolver = $customAttachablesResolver;
     }

--- a/src/RichTextLaravel.php
+++ b/src/RichTextLaravel.php
@@ -2,7 +2,9 @@
 
 namespace Tonysm\RichTextLaravel;
 
+use DOMElement;
 use Illuminate\Support\Facades\Crypt;
+use Tonysm\RichTextLaravel\Attachables\AttachableContract;
 
 class RichTextLaravel
 {
@@ -19,6 +21,13 @@ class RichTextLaravel
      * @var callable
      */
     protected static $decryptHandler;
+
+    /**
+     * The custom content attachment resolver (if any).
+     *
+     * @var callable
+     */
+    protected static $customAttachablesResolver;
 
     /**
      * Override the way the package handles encryption.
@@ -54,5 +63,22 @@ class RichTextLaravel
         $decrypt = static::$decryptHandler ??= fn ($value) => Crypt::decryptString($value);
 
         return $value ? call_user_func($decrypt, $value, $model, $key) : $value;
+    }
+
+    public static function withCustomAttachables($customAttachablesResolver): void
+    {
+        static::$customAttachablesResolver = $customAttachablesResolver;
+    }
+
+    public static function clearCustomAttachables(): void
+    {
+        static::withCustomAttachables(null);
+    }
+
+    public static function attachableFromCustomResolver(DOMElement $node): ?AttachableContract
+    {
+        $resolver = static::$customAttachablesResolver ?? fn () => null;
+
+        return $resolver($node);
     }
 }

--- a/tests/ContentTest.php
+++ b/tests/ContentTest.php
@@ -6,6 +6,7 @@ use Tonysm\RichTextLaravel\Attachables\MissingAttachable;
 use Tonysm\RichTextLaravel\Attachables\RemoteImage;
 use Tonysm\RichTextLaravel\Attachment;
 use Tonysm\RichTextLaravel\Content;
+use Workbench\App\Models\Opengraph\OpengraphEmbed;
 use Workbench\App\Models\User;
 use Workbench\Database\Factories\UserFactory;
 
@@ -542,6 +543,30 @@ class ContentTest extends TestCase
             <figure data-trix-attachment='{"contentType":"vnd.richtextlaravel.horizontal-rule.html","content":"&lt;hr&gt;\n"}'></figure>
         </div>
         HTML, $content->toTrixHtml());
+    }
+
+    /** @test */
+    public function supports_custom_content_attachments_without_sgid()
+    {
+        $contentType = OpengraphEmbed::CONTENT_TYPE;
+
+        $content = $this->fromHtml(<<<HTML
+        <div>
+            Testing out with cards: <a href="https://github.com/tonysm/rich-text-laravel">https://github.com/tonysm/rich-text-laravel</a>
+            <rich-text-attachment
+                caption="Integrates the Trix Editor with Laravel. Inspired by the Action Text gem from Rails. - tonysm/rich-text-laravel"
+                content-type="{$contentType}"
+                filename="GitHub - tonysm/rich-text-laravel: Integrates the Trix Editor with Laravel. Inspired by the Action Text gem from Rails."
+                href="https://github.com/tonysm/rich-text-laravel"
+                url="https://opengraph.githubassets.com/7e956bd233205f222790d8cdbdadfc401886aabdc88a8fd0cfb3c7dcca44d635/tonysm/rich-text-laravel"
+            ></rich-text-attachment>
+        </div>
+        HTML);
+
+        $this->assertCount(1, $content->attachments());
+        $this->assertCount(1, $content->attachables());
+        $this->assertInstanceOf(OpengraphEmbed::class, $content->attachables()->first());
+        $this->assertEquals('https://github.com/tonysm/rich-text-laravel', $content->attachables()->first()->href);
     }
 
     private function withAttachmentTagName(string $tagName, callable $callback)

--- a/workbench/app/Models/Opengraph/OpengraphEmbed.php
+++ b/workbench/app/Models/Opengraph/OpengraphEmbed.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Workbench\App\Models\Opengraph;
+
+use DOMElement;
+use Tonysm\RichTextLaravel\Attachables\AttachableContract;
+
+class OpengraphEmbed implements AttachableContract
+{
+    use OpengraphEmbed\Fetching;
+
+    const ATTRIBUTES = ['title', 'url', 'image', 'description'];
+    const CONTENT_TYPE = 'application/vnd.rich-text-laravel.opengraph-embed';
+
+    public static function fromNode(DOMElement $node): ?OpengraphEmbed
+    {
+        if ($node->hasAttribute('content-type') && $node->getAttribute('content-type') === static::CONTENT_TYPE) {
+            return new OpengraphEmbed(...static::attributesFromNode($node));
+        }
+
+        return null;
+    }
+
+    public static function tryFromAttributes(array $attributes)
+    {
+        if (validator($attributes, [
+            'title' => ['required'],
+            'url' => ['required'],
+            'description' => ['required'],
+            'image' => ['sometimes', 'required', 'url'],
+        ])->fails()) {
+            return null;
+        }
+
+        return new static(
+            $attributes['url'],
+            $attributes['image'] ?? null,
+            $attributes['title'],
+            $attributes['description'],
+        );
+    }
+
+    private static function attributesFromNode(DOMElement $node): array
+    {
+        return [
+            'href' => $node->getAttribute('href'),
+            'url' => $node->getAttribute('url'),
+            'filename' => $node->getAttribute('filename'),
+            'description' => $node->getAttribute('caption'),
+        ];
+    }
+
+    public function __construct(
+        public $href,
+        public $url,
+        public $filename,
+        public $description,
+    ) {}
+
+    public function toRichTextAttributes(array $attributes): array
+    {
+        return collect($attributes)
+            ->replace([
+                'content_type' => $this->richTextContentType(),
+                'previewable' => true,
+            ])
+            ->filter()
+            ->all();
+    }
+
+    public function equalsToAttachable(AttachableContract $attachable): bool
+    {
+        return $this->richTextRender() === $attachable->richTextRender();
+    }
+
+    public function richTextRender(array $options = []): string
+    {
+        return view('rich-text-laravel.attachables.opengraph_embed', [
+            'attachable' => $this
+        ])->render();
+    }
+
+    public function richTextAsPlainText(?string $caption = null): string
+    {
+        return '';
+    }
+
+    public function richTextContentType(): string
+    {
+        return static::CONTENT_TYPE;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'href' => $this->href,
+            'url' => $this->url,
+            'filename' => $this->filename,
+            'description' => $this->description,
+            'contentType' => $this->richTextContentType(),
+            'content' => $this->richTextRender(),
+        ];
+    }
+}

--- a/workbench/app/Models/Opengraph/OpengraphEmbed.php
+++ b/workbench/app/Models/Opengraph/OpengraphEmbed.php
@@ -10,6 +10,7 @@ class OpengraphEmbed implements AttachableContract
     use OpengraphEmbed\Fetching;
 
     const ATTRIBUTES = ['title', 'url', 'image', 'description'];
+
     const CONTENT_TYPE = 'application/vnd.rich-text-laravel.opengraph-embed';
 
     public static function fromNode(DOMElement $node): ?OpengraphEmbed
@@ -55,7 +56,8 @@ class OpengraphEmbed implements AttachableContract
         public $url,
         public $filename,
         public $description,
-    ) {}
+    ) {
+    }
 
     public function toRichTextAttributes(array $attributes): array
     {
@@ -76,7 +78,7 @@ class OpengraphEmbed implements AttachableContract
     public function richTextRender(array $options = []): string
     {
         return view('rich-text-laravel.attachables.opengraph_embed', [
-            'attachable' => $this
+            'attachable' => $this,
         ])->render();
     }
 

--- a/workbench/app/Models/Opengraph/OpengraphEmbed/Fetching.php
+++ b/workbench/app/Models/Opengraph/OpengraphEmbed/Fetching.php
@@ -47,15 +47,19 @@ trait Fetching
     private static function extractAttributesFromDocument(DOMDocument $document): array
     {
         $xpath = new DOMXPath($document);
-        $openGraphTags = $xpath->query("//meta[starts-with(@property, \"og:\") or starts-with(@name, \"og:\")]");
+        $openGraphTags = $xpath->query('//meta[starts-with(@property, "og:") or starts-with(@name, "og:")]');
         $attributes = [];
 
         foreach ($openGraphTags as $tag) {
-            if (! $tag->hasAttribute('content')) continue;
+            if (! $tag->hasAttribute('content')) {
+                continue;
+            }
 
             $key = str_replace('og:', '', $tag->hasAttribute('property') ? $tag->getAttribute('property') : $tag->getAttribute('name'));
 
-            if (! in_array($key, OpengraphEmbed::ATTRIBUTES, true)) continue;
+            if (! in_array($key, OpengraphEmbed::ATTRIBUTES, true)) {
+                continue;
+            }
 
             $attributes[$key] = $tag->getAttribute('content');
         }

--- a/workbench/app/Models/Opengraph/OpengraphEmbed/Fetching.php
+++ b/workbench/app/Models/Opengraph/OpengraphEmbed/Fetching.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Workbench\App\Models\Opengraph\OpengraphEmbed;
+
+use DOMDocument;
+use DOMXPath;
+use Illuminate\Support\Facades\Http;
+use Tonysm\RichTextLaravel\HtmlConversion;
+use Workbench\App\Models\Opengraph\OpengraphEmbed;
+
+trait Fetching
+{
+    public static function createFromUrl(string $url): ?OpengraphEmbed
+    {
+        $attributes = static::extractAttributesFromDocument(static::fetchDocument($url));
+
+        return OpengraphEmbed::tryFromAttributes($attributes);
+    }
+
+    private static function fetchDocument(string $url)
+    {
+        return HtmlConversion::document(
+            Http::withUserAgent('curl/7.81.0')
+                ->maxRedirects(10)
+                ->get(static::replaceTwitterDomainFromTweetUrls($url))
+                ->throw()
+                ->body()
+        );
+    }
+
+    private static function replaceTwitterDomainFromTweetUrls(string $url)
+    {
+        $domains = [
+            'www.x.com',
+            'www.twitter.com',
+            'twitter.com',
+            'x.com',
+        ];
+
+        $host = parse_url($url)['host'];
+
+        return in_array($host, $domains, strict: true)
+            ? str_replace($host, 'fxtwitter.com', $url)
+            : $url;
+    }
+
+    private static function extractAttributesFromDocument(DOMDocument $document): array
+    {
+        $xpath = new DOMXPath($document);
+        $openGraphTags = $xpath->query("//meta[starts-with(@property, \"og:\") or starts-with(@name, \"og:\")]");
+        $attributes = [];
+
+        foreach ($openGraphTags as $tag) {
+            if (! $tag->hasAttribute('content')) continue;
+
+            $key = str_replace('og:', '', $tag->hasAttribute('property') ? $tag->getAttribute('property') : $tag->getAttribute('name'));
+
+            if (! in_array($key, OpengraphEmbed::ATTRIBUTES, true)) continue;
+
+            $attributes[$key] = $tag->getAttribute('content');
+        }
+
+        return $attributes;
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -2,10 +2,13 @@
 
 namespace Workbench\App\Providers;
 
+use DOMElement;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Livewire\LivewireManager;
+use Tonysm\RichTextLaravel\RichTextLaravel;
 use Workbench\App\Livewire\Posts;
+use Workbench\App\Models\Opengraph\OpengraphEmbed;
 
 class WorkbenchServiceProvider extends ServiceProvider
 {
@@ -23,12 +26,22 @@ class WorkbenchServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerComponents();
+        $this->registerCustomRichTextAttachables();
     }
 
     public function registerComponents(): void
     {
         $this->callAfterResolving('livewire', function (LivewireManager $livewire, Application $app) {
             $livewire->component('posts.index', Posts::class);
+        });
+    }
+
+    public function registerCustomRichTextAttachables(): void
+    {
+        RichTextLaravel::withCustomAttachables(function (DOMElement $node) {
+            if ($attachable = OpengraphEmbed::fromNode($node)) {
+                return $attachable;
+            }
         });
     }
 }

--- a/workbench/resources/views/chat/partials/trix-input.blade.php
+++ b/workbench/resources/views/chat/partials/trix-input.blade.php
@@ -2,14 +2,15 @@
 
 <trix-editor
     placeholder="Say something nice..."
+    data-controller="rich-text-mentions oembed"
+    data-oembed-target="text"
     data-composer-target="text"
-    data-controller="rich-text-mentions"
-    data-action="keydown->composer#submitByKeyboard tribute-replaced->rich-text-mentions#addMention tribute-active-true->composer#disableSubmitByKeyboard tribute-active-false->composer#enableSubmitByKeyboard trix-attachment-add->composer#rejectFiles"
+    data-action="trix-paste->oembed#pasted keydown->composer#submitByKeyboard tribute-replaced->rich-text-mentions#addMention tribute-active-true->composer#disableSubmitByKeyboard tribute-active-false->composer#enableSubmitByKeyboard trix-attachment-add->composer#rejectFiles"
     id="create_message"
     name="content"
     toolbar="create_message_toolbar"
     input="create_message_input"
-    class="trix-content overflow-auto rounded-0 p-0 [&_pre]:text-sm min-h-0 max-h-[12vh] border-0 sm:group-data-[composer-show-toolbar-value=true]:py-2 sm:group-data-[composer-show-toolbar-value=true]:min-h-[4em]"
+    class="trix-content rounded-0 p-0 [&_pre]:text-sm min-h-0 max-h-[90vh] border-0 sm:group-data-[composer-show-toolbar-value=true]:py-2 sm:group-data-[composer-show-toolbar-value=true]:min-h-[4em]"
 ></trix-editor>
 
 <trix-toolbar js-cloak id="create_message_toolbar" class="[&_.trix-button-group]:!mb-0 sm:group-data-[composer-show-toolbar-value=true]:mt-2">

--- a/workbench/resources/views/chat/partials/trix-input.blade.php
+++ b/workbench/resources/views/chat/partials/trix-input.blade.php
@@ -10,7 +10,7 @@
     name="content"
     toolbar="create_message_toolbar"
     input="create_message_input"
-    class="trix-content rounded-0 p-0 [&_pre]:text-sm min-h-0 max-h-[90vh] border-0 sm:group-data-[composer-show-toolbar-value=true]:py-2 sm:group-data-[composer-show-toolbar-value=true]:min-h-[4em]"
+    class="trix-content overflow-auto rounded-0 p-0 [&_pre]:text-sm min-h-0 max-h-[90vh] border-0 sm:group-data-[composer-show-toolbar-value=true]:py-2 sm:group-data-[composer-show-toolbar-value=true]:min-h-[4em]"
 ></trix-editor>
 
 <trix-toolbar js-cloak id="create_message_toolbar" class="[&_.trix-button-group]:!mb-0 sm:group-data-[composer-show-toolbar-value=true]:mt-2">

--- a/workbench/resources/views/components/app-layout.blade.php
+++ b/workbench/resources/views/components/app-layout.blade.php
@@ -29,6 +29,25 @@
         }
     </script>
 
+    <style type="text/tailwindcss">
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+        @layer base {
+            .trix-content figure[data-trix-mutable=true] > :first-child {
+                @apply ring-2 ring-offset-2;
+            }
+
+            .trix-content figure[data-trix-mutable=true]:where(:has(.oembed)) > :first-child {
+                @apply rounded;
+            }
+
+            .trix-content figure[data-trix-mutable=true] img {
+                @apply ring-0 outline-none;
+            }
+        }
+    </style>
+
     <x-rich-text::styles theme="richtextlaravel" />
 
     {{-- Tribute's Styles... --}}
@@ -47,7 +66,7 @@
             Controller
         } from 'https://cdn.skypack.dev/@hotwired/stimulus'
         import Tribute from 'https://ga.jspm.io/npm:tributejs@5.1.3/dist/tribute.min.js'
-        import Trix from 'https://ga.jspm.io/npm:trix@2.0.10/dist/trix.esm.min.js'
+        import Trix from 'https://ga.jspm.io/npm:trix@2.1.0/dist/trix.esm.min.js'
 
         [...document.querySelectorAll('[js-cloak]')].forEach(el => el.removeAttribute('js-cloak'))
 
@@ -233,6 +252,101 @@
 
             get #usingTouchDevice() {
                 return "ontouchstart" in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
+            }
+        })
+
+        Stimulus.register("oembed", class extends Controller {
+            static targets = ["text"]
+
+            #abortController
+
+            pasted(event) {
+                const { range } = event.paste
+
+                if (! range) return
+
+                const url = this.#urlFromRange(range)
+
+                if (! url) return
+
+                this.#convertToLink(url, range)
+                this.#processOembed(url)
+            }
+
+            #urlFromRange(range) {
+                const document = this.#editor.getDocument()
+
+                const string = document.getStringAtRange(range)
+                const trimmed = string.trim()
+
+                const startOffset = range[0] + string.indexOf(trimmed)
+                const endOffset = startOffset + trimmed.length
+
+                const url = document.getStringAtRange([startOffset, endOffset])
+
+                if (! this.#isValidUrl(url)) {
+                    return null;
+                }
+
+                return url;
+            }
+
+            #isValidUrl(url) {
+                return /^(?:[a-z0-9]+:\/\/|www\.)[^\s]+$/.test(url)
+            }
+
+            #convertToLink(url, range) {
+                const currentRange = this.#editor.getSelectedRange()
+
+                this.#editor.setSelectedRange(range)
+                this.#editor.recordUndoEntry("Convert Pasted URL to Link")
+                this.#editor.activateAttribute('href', url)
+                this.#editor.setSelectedRange(currentRange)
+            }
+
+            #processOembed(url) {
+                this.#fetchOpengraphMetadata(url)
+                    .then((response) => response.json())
+                    .then(this.#insertOpengraphAttachment.bind(this))
+                    .catch(() => null)
+            }
+
+            #fetchOpengraphMetadata(url) {
+                this.#abortController?.abort()
+                this.#abortController = new AbortController()
+
+                return fetch('/opengraph-embeds', {
+                    method: 'POST',
+                    body: JSON.stringify({ url }),
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                        'X-CSRF-TOKEN': document.head.querySelector('[name=csrf-token]').content,
+                    },
+                    signal: this.#abortController.signal,
+                })
+            }
+
+            #insertOpengraphAttachment(attributes) {
+                if (! this.#shouldInsertOpengraphAttachment(attributes.href)) return;
+
+                const currentRange = this.#editor.getSelectedRange()
+
+                this.#editor.setSelectedRange(this.#editor.getSelectedRange())
+                this.#editor.recordUndoEntry("Insert Opengraph preview for Pasted URL")
+                this.#editor.insertAttachment(new Trix.Attachment({
+                    ...attributes,
+                    caption: attributes.description,
+                }))
+                this.#editor.setSelectedRange(currentRange)
+            }
+
+            #shouldInsertOpengraphAttachment(url) {
+                return this.#editor.getDocument().toString().includes(url)
+            }
+
+            get #editor() {
+                return this.textTarget.editor
             }
         })
     </script>

--- a/workbench/resources/views/components/app-layout.blade.php
+++ b/workbench/resources/views/components/app-layout.blade.php
@@ -260,6 +260,10 @@
 
             #abortController
 
+            disconnect() {
+                this.#abortController?.abort()
+            }
+
             pasted(event) {
                 const { range } = event.paste
 

--- a/workbench/resources/views/rich-text-laravel/attachables/opengraph_embed.blade.php
+++ b/workbench/resources/views/rich-text-laravel/attachables/opengraph_embed.blade.php
@@ -1,0 +1,7 @@
+<div class="oembed my-2">
+    @if (str_contains($attachable->href, 'twitter.com') || str_contains($attachable->href, 'x.com'))
+        @include('rich-text-laravel.attachables.partials.twitter-card', ['attachable' => $attachable])
+    @else
+        @include('rich-text-laravel.attachables.partials.opengraph-card', ['attachable' => $attachable])
+    @endif
+</div>

--- a/workbench/resources/views/rich-text-laravel/attachables/partials/opengraph-card.blade.php
+++ b/workbench/resources/views/rich-text-laravel/attachables/partials/opengraph-card.blade.php
@@ -1,0 +1,9 @@
+<div class="border rounded text-sm shadow p-2 grid gap-4 divide-y">
+    @if ($attachable->url)
+    <img class="!m-0 !p-0" src="{{ $attachable->url }}" alt="">
+    @endif
+    <div class="pt-1 space-y-2">
+        <div class="font-semibold"><a href="{{ $attachable->href }}" class="no-underline" rel="noreferrer" target="_blank">{{ $attachable->filename }}</a></div>
+        <div class="text-xs">{{ $attachable->description }}</div>
+    </div>
+</div>

--- a/workbench/resources/views/rich-text-laravel/attachables/partials/twitter-card.blade.php
+++ b/workbench/resources/views/rich-text-laravel/attachables/partials/twitter-card.blade.php
@@ -1,0 +1,9 @@
+<div class="border rounded text-sm shadow p-2 grid grid-cols-6 gap-4">
+    <div class="col-span-5 space-y-2">
+        <div class="font-semibold"><a href="{{ $attachable->href }}" class="no-underline" rel="noreferrer" target="_blank">{{ $attachable->filename }}</a></div>
+        <div class="text-xs">{{ $attachable->description }}</div>
+    </div>
+    @if ($attachable->url)
+    <img class="rounded-full !m-0 !p-0" src="{{ $attachable->url }}" alt="">
+    @endif
+</div>

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -137,7 +137,7 @@ Route::get('/attachments/{path}', function (string $path) {
 
 Route::post('/opengraph-embeds', function (Request $request) {
     $request->validate(['url' => [
-        'bail', 'required', 'url', function (string $attribute, mixed $value,  Closure $fail) {
+        'bail', 'required', 'url', function (string $attribute, mixed $value, Closure $fail) {
             $ip = gethostbyname($host = parse_url($value)['host']);
 
             // Prevent sniffing domains resolved to private IP ranges...

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
 use Workbench\App\Models\Message;
+use Workbench\App\Models\Opengraph\OpengraphEmbed;
 use Workbench\App\Models\Post;
 use Workbench\App\Models\User;
 
@@ -133,3 +134,22 @@ Route::get('/attachments/{path}', function (string $path) {
 
     return response()->stream(fn () => fpassthru($stream), 200, $headers);
 })->name('attachments.show')->where('path', '.*');
+
+Route::post('/opengraph-embeds', function (Request $request) {
+    $request->validate(['url' => [
+        'bail', 'required', 'url', function (string $attribute, mixed $value,  Closure $fail) {
+            $ip = gethostbyname($host = parse_url($value)['host']);
+
+            // Prevent sniffing domains resolved to private IP ranges...
+            if ($ip === $host || filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+                $fail(__('URL is invalid.'));
+            }
+        },
+    ]]);
+
+    if ($opengraph = OpengraphEmbed::createFromUrl($request->url)) {
+        return $opengraph->toArray();
+    }
+
+    return response()->noContent();
+});


### PR DESCRIPTION
### Added

- Adds support for custom content attachments that don't require an SGID (we can map them straight from the document)

---

closes #54 