### PR TITLE
feat: add safety migration rollback on rich_texts table

### DIFF
--- a/database/migrations/create_rich_texts_table.php.stub
+++ b/database/migrations/create_rich_texts_table.php.stub
@@ -17,4 +17,9 @@ return new class extends Migration {
             $table->unique(['field', 'record_type', 'record_id']);
         });
     }
+
+    public function down()
+    {
+        Schema::dropIfExists('rich_texts');
+    }
 };


### PR DESCRIPTION
Hi Tony, I create a PR to add safety migration rollback on rich_texts table. 

I just finished watch your first video (Rich Text Laravel) episode 1:  Installation, Migrating Existing Data, and Encrypted Attributes in Rich Text Laravel video series. Sometimes, I forget is that I already do a rollback (`migrate:rollback --step=1`) when update the existing messages in Chirp table into content in rich_text table? At some point I get error that `rich_texts` table already exists.