### PR TITLE
Ensure setting a rich text attribute to null clears the value

### DIFF
--- a/src/Casts/ForwardsAttributeToRelationship.php
+++ b/src/Casts/ForwardsAttributeToRelationship.php
@@ -19,7 +19,7 @@ class ForwardsAttributeToRelationship implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        if (is_string($value)) {
+        if (is_string($value) || is_null($value)) {
             $richText = $this->firstOrNewRelationship($model, $key);
             $richText->fill(['body' => $value]);
         }

--- a/tests/AttributeRichTextTest.php
+++ b/tests/AttributeRichTextTest.php
@@ -226,6 +226,23 @@ class AttributeRichTextTest extends TestCase
         // The content should be canonicalized (Trix figure converted to rich-text-attachment)
         $this->assertStringContainsString('rich-text-attachment', $rawBody);
     }
+
+    #[Test]
+    public function can_clear_local_attribute_with_null(): void
+    {
+        $page = Page::create([
+            'title' => 'Title example',
+            'body' => 'Body example',
+        ]);
+
+        $page->refresh()->update(['body' => null]);
+
+        $this->assertEquals(<<<'HTML'
+        <div class="trix-content">
+        </div>
+
+        HTML, "{$page->refresh()->body}");
+    }
 }
 
 class PageWithMixedFields extends Page

--- a/tests/EncryptedModelTest.php
+++ b/tests/EncryptedModelTest.php
@@ -20,11 +20,29 @@ class EncryptedModelTest extends TestCase
         $this->assertNotEncryptedRichTextAttribute($clearMessage, 'content', 'Hello World');
     }
 
-    private function assertEncryptedRichTextAttribute($model, string $field, string $expectedValue): void
+    #[Test]
+    public function can_clear_encrypted_content_with_null(): void
     {
-        $this->assertStringNotContainsString($expectedValue, $encrypted = DB::table('rich_texts')->where('record_id', $model->id)->value('body'));
-        $this->assertEquals($expectedValue, RichTextLaravel::decrypt($encrypted, $model, $field));
-        $this->assertStringContainsString($expectedValue, $model->refresh()->{$field}->body->toHtml());
+        $encryptedMessage = EncryptedMessage::create(['content' => 'Hello World']);
+
+        $encryptedMessage->update(['content' => null]);
+
+        $this->assertEncryptedRichTextAttribute($encryptedMessage->refresh(), 'content', null);
+    }
+
+    private function assertEncryptedRichTextAttribute($model, string $field, ?string $expectedValue): void
+    {
+        $encrypted = DB::table('rich_texts')->where('record_id', $model->id)->value('body');
+
+        if (is_null($expectedValue)) {
+            $this->assertNotNull($encrypted);
+            $this->assertEquals("\n", RichTextLaravel::decrypt($encrypted, $model, $field));
+            $this->assertEquals('', $model->refresh()->{$field}->body->toHtml());
+        } else {
+            $this->assertStringNotContainsString($expectedValue, $encrypted);
+            $this->assertEquals($expectedValue, RichTextLaravel::decrypt($encrypted, $model, $field));
+            $this->assertStringContainsString($expectedValue, $model->refresh()->{$field}->body->toHtml());
+        }
     }
 
     public function assertNotEncryptedRichTextAttribute($model, $field, string $expectedValue): void

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -156,4 +156,22 @@ class ModelTest extends TestCase
 
         $this->assertTrue($post->refresh()->created_at->eq($post->refresh()->updated_at), 'Record timestamps were touched, but it shouldnt.');
     }
+
+    #[Test]
+    public function can_clear_rich_text_attribute_with_null(): void
+    {
+        $post = PostFactory::new()->create([
+            'body' => '<h1>Old Value</h1>',
+        ])->fresh();
+
+        $post->update([
+            'body' => null,
+        ]);
+
+        $this->assertEquals(<<<'HTML'
+        <div class="trix-content">
+        </div>
+
+        HTML, "{$post->refresh()->body}");
+    }
 }


### PR DESCRIPTION
### Changed

- Allow clearing rich text attributes with nulls