### PR TITLE
Update Lexxy link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <a href="https://packagist.org/packages/tonysm/rich-text-laravel"><img src="https://img.shields.io/github/license/tonysm/rich-text-laravel" alt="License"></a>
 </p>
 
-Integrates rich text editors like [Trix](https://trix-editor.org/) and [Lexxy](https://github.com/nicholasgasior/lexxy) with Laravel. Inspired by the Action Text gem from Rails.
+Integrates rich text editors like [Trix](https://trix-editor.org/) and [Lexxy](https://lexxy.dev/) with Laravel. Inspired by the Action Text gem from Rails.
 
 ## Table of Contents
 


### PR DESCRIPTION
The link was previously pointing to a [repository that didn't exist](https://github.com/nicholasgasior/lexxy). The link now points to Lexxy's new website. There is also the [official repository on GitHub](https://github.com/basecamp/lexxy), but I thought linking to the website aligns with the [Trix Editor link](https://trix-editor.org/).

Thanks for this package, and for supporting Lexxy!